### PR TITLE
Use the existing protocol when connecting to the flicker API

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -25,7 +25,9 @@ require([
 
 		pi.active = true;
 
-		var url = "http://api.flickr.com/services/feeds/photos_public.gne?format=json&jsoncallback=photosReceived&tags=" +
+		var protocol = window.location.protocol || "http:",
+			url = protocol +
+			"//api.flickr.com/services/feeds/photos_public.gne?format=json&jsoncallback=photosReceived&tags=" +
 			tags + "&tagmode=" + settings.tagMode;
 		script = document.createElement("script");
 		script.type = "text/javascript";


### PR DESCRIPTION
Testing the tutorial on https hangs -
"[blocked] The page at 'https://deliteful-tutorial-c9-funland.c9.io/index.html' was loaded over HTTPS, but ran insecure content from 'http://api.flickr.com/services/feeds/photos_public.gne?format=json&jsoncallback=photosReceived&tags=famous,bridges&tagmode=all': this content should also be loaded over HTTPS." 

Updated the flicker API request to reuse the existing protocol.
